### PR TITLE
FPS表示の非表示、ヘルプボタンのバグの修正

### DIFF
--- a/furufuru-ball-ios/furufuru-ball-ios/GameScene.swift
+++ b/furufuru-ball-ios/furufuru-ball-ios/GameScene.swift
@@ -91,6 +91,7 @@ class GameScene: SKScene, SRWebSocketDelegate{
                     start_label.hidden = false
                     start_label.name = "START"
                     help.hidden = false
+                    help.name = "Help"
                     join_label.hidden = false
                     webSocketConnect()
                 }
@@ -98,6 +99,7 @@ class GameScene: SKScene, SRWebSocketDelegate{
             if touchNode.name == "Help"{
                 let dialog = CustomDialog(scene: self, frame:CGRectMake(0, 0,300, 400))
                 self.view!.addSubview(dialog)
+    
             }
             
             //スタートをタッチでサーバーに伝達
@@ -132,6 +134,7 @@ class GameScene: SKScene, SRWebSocketDelegate{
         start_label.hidden = true
         start_label.name = ""
         help.hidden = true
+        help.name = ""
     }
     
     //0.01秒ごと呼ばれる関数

--- a/furufuru-ball-ios/furufuru-ball-ios/GameViewController.swift
+++ b/furufuru-ball-ios/furufuru-ball-ios/GameViewController.swift
@@ -33,8 +33,8 @@ class GameViewController: UIViewController {
         if let scene = GameScene.unarchiveFromFile("GameScene") as? GameScene {
             // Configure the view.
             let skView = self.view as! SKView
-            skView.showsFPS = true
-            skView.showsNodeCount = true
+            skView.showsFPS = false
+            skView.showsNodeCount = false
             
             /* Sprite Kit applies additional optimizations to improve rendering performance */
             skView.ignoresSiblingOrder = true


### PR DESCRIPTION
FPSの非表示。
ヘルプボタンがゲームプレイ中でも押せたので修正しました。
![ios simulator screen shot 2015 08 20 17 06 47](https://cloud.githubusercontent.com/assets/13843420/9378676/342c973a-475e-11e5-9047-31d6cd32c671.png)
